### PR TITLE
Update syntax to allow nested variables

### DIFF
--- a/gclient/syntaxes/feature.tmLanguage
+++ b/gclient/syntaxes/feature.tmLanguage
@@ -153,9 +153,9 @@
     <key>strings_double_quote</key>
     <dict>
       <key>begin</key>
-      <string>"</string>
+      <string>(?&lt;![a-zA-Z'])"</string>
       <key>end</key>
-      <string>"</string>
+      <string>"(?![a-zA-Z'])</string>
       <key>name</key>
       <string>string.quoted.double</string>
       <key>patterns</key>
@@ -166,6 +166,14 @@
           <key>name</key>
           <string>constant.character.escape.untitled</string>
         </dict>
+        <dict>
+          <key>begin</key>
+          <string>&lt;</string>
+          <key>end</key>
+          <string>&gt;</string>
+          <key>name</key>
+          <string>variable.other</string>
+        </dict>
       </array>
     </dict>
     <key>strings_single_quote</key>
@@ -173,7 +181,7 @@
       <key>begin</key>
       <string>(?&lt;![a-zA-Z"])'</string>
       <key>end</key>
-      <string>'(?![a-zA-Z])</string>
+      <string>'(?![a-zA-Z"])</string>
       <key>name</key>
       <string>string.quoted.single</string>
       <key>patterns</key>
@@ -183,6 +191,14 @@
           <string>\\.</string>
           <key>name</key>
           <string>constant.character.escape</string>
+        </dict>
+        <dict>
+          <key>begin</key>
+          <string>&lt;</string>
+          <key>end</key>
+          <string>&gt;</string>
+          <key>name</key>
+          <string>variable.other</string>
         </dict>
       </array>
     </dict>


### PR DESCRIPTION
This allows for nested variable syntax as follows:

![with.png](http://i.imgur.com/Ha6CbB7.png)

Otherwise it looks like the following

![without.png](http://i.imgur.com/8dAEe68.png)